### PR TITLE
Fix memory leak within init_rad_ccsn.c

### DIFF
--- a/problems/init_rad_ccsn.c
+++ b/problems/init_rad_ccsn.c
@@ -332,6 +332,7 @@ void init_problem()
     free(ye_model);
     free(v_model);
     free(s_model);
+    free(rad_model);
     free(lapse_model);
     free(lapse_edge_model);
 


### PR DESCRIPTION
Fix direct leak of memory caused by not free'ing `rad_model`.